### PR TITLE
Local storage

### DIFF
--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/storage/LocalCache.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/storage/LocalCache.java
@@ -1,0 +1,29 @@
+package com.github.houseorganizer.houseorganizer.storage;
+
+import androidx.annotation.NonNull;
+
+import java.util.LinkedHashMap;
+
+public class LocalCache {
+    protected static LinkedHashMap<CacheKey, Object> cache = new LinkedHashMap<CacheKey, Object>();
+
+    public static boolean contains(CacheKey key){
+        return cache.containsKey(key);
+    }
+
+    public static void put(CacheKey key, Object object){
+        if(cache.containsKey(key)){
+            cache.replace(key, object);
+        } else {
+            cache.put(key, object);
+        }
+    }
+
+    public static Object get(CacheKey key){
+        return cache.get(key);
+    }
+
+    public enum CacheKey{
+        HOUSEHOLD, EVENT, TASK
+    }
+}

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/storage/LocalStorage.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/storage/LocalStorage.java
@@ -1,0 +1,23 @@
+package com.github.houseorganizer.houseorganizer.storage;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import android.content.Context;
+
+public class LocalStorage {
+    public static boolean writeTxtToFile(Context context, String fileName, String content){
+        File path = context.getFilesDir();
+        try {
+            FileOutputStream writer = new FileOutputStream(new File(path, fileName));
+            writer.write(content.getBytes(StandardCharsets.UTF_8));
+            writer.close();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This is related to my task "investigate local storage on the device". A new package was added "storage" where there are two classes. LocalStorage offers a helper to store text files on the device itself. LocalCache offers an interface to interact with a shared cache which is alive only during the lifetime of the app. The idea of the enum in the shared cache is to have a common ground for the keys we use, instead of just random strings.