### PR TITLE
Feature/link task lists with households and users

### DIFF
--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
  *
  */
 public class FirebaseTestsHelper {
+    public static final String TEST_TASK_TITLE = "TestTask";
+    public static final String TEST_TASK_DESC = "Testing";
     private static boolean authEmulatorActivated = false;
     private static boolean firestoreEmulatorActivated = false;
     private static boolean databaseEmulatorActivated = false;
@@ -143,16 +145,16 @@ public class FirebaseTestsHelper {
     }
 
     /**
-     * This method will create a task list | TODO UPDATE
+     * This method will create a task list
      */
     protected static void createTestTaskList(String hhID) throws ExecutionException, InterruptedException {
         // Get DB ref
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         // Create task list instance
-        HTask taskToAdd = new HTask(TEST_USERS_EMAILS[0], "TestTask", "Testing");
+        HTask taskToAdd = new HTask(TEST_USERS_EMAILS[0], TEST_TASK_TITLE, TEST_TASK_DESC);
 
-        TaskList taskList = new TaskList(TEST_USERS_EMAILS[0], "MyList",
+        TaskList taskList = new TaskList(TEST_USERS_EMAILS[0], FIRST_TL_NAME,
                 new ArrayList<>(Collections.singletonList(taskToAdd)));
 
         // Store instance on the database using a helper function

--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
@@ -284,7 +284,7 @@ public class FirebaseTestsHelper {
     }
 
     /**
-     * This method will create 8 users, 3 households, a task list and a list of events
+     * This method will create 8 users, 3 households (each with a task list) and a list of events
      * After this call user_1 is logged in
      * A flag allows us to just login as user_1 if everything is already done
      */
@@ -307,9 +307,6 @@ public class FirebaseTestsHelper {
         }
 
         createHouseholds();
-
-        //createTestTaskList(); [MOVED TO `CREATE TEST HH` SINCE TLs NOW LINKED TO HHs]
-      
         createTestShopList();
 
         createTestEvents();

--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
@@ -146,18 +146,17 @@ public class FirebaseTestsHelper {
     }
 
     /**
-     * This method will create a task list
+     * This method will create a task list | TODO UPDATE
      */
     protected static void createTestTaskList(String hhID) throws ExecutionException, InterruptedException {
         // Get DB ref
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         // Create task list instance
-        User owner = new DummyUser("Test User", "0");
-        HTask taskToAdd =
-                new HTask(owner, "TestTask", "Testing");
+        HTask taskToAdd = new HTask(TEST_USERS_EMAILS[0], "TestTask", "Testing");
 
-        TaskList taskList = new TaskList(owner, "MyList", new ArrayList<>(Collections.singletonList(taskToAdd)));
+        TaskList taskList = new TaskList(TEST_USERS_EMAILS[0], "MyList",
+                new ArrayList<>(Collections.singletonList(taskToAdd)));
 
         // Store instance on the database using a helper function
         // returns only after storing is done
@@ -330,13 +329,8 @@ public class FirebaseTestsHelper {
         data.put("title", task.getTitle());
         data.put("description", task.getDescription());
         data.put("status", task.isFinished() ? "completed" : "ongoing");
-        data.put("owner", task.getOwner().uid());
-
-        data.put("assignees",
-                task.getAssignees()
-                        .stream()
-                        .map(User::uid)
-                        .collect(Collectors.toList()));
+        data.put("owner", task.getOwner());
+        data.put("assignees", task.getAssignees());
 
         data.put("sub tasks",
                 task.getSubTasks()
@@ -364,7 +358,7 @@ public class FirebaseTestsHelper {
         Map<String, Object> data = new HashMap<>();
 
         data.put("title", taskList.getTitle());
-        data.put("owner", taskList.getOwner().uid());
+        data.put("owner", taskList.getOwner());
         data.put("hh-id", hhID);
         data.put("task-ptrs", taskPtrs);
 

--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirebaseTestsHelper.java
@@ -366,11 +366,13 @@ public class FirebaseTestsHelper {
         data.put("title", taskList.getTitle());
         data.put("owner", taskList.getOwner().uid());
         data.put("hh-id", hhID);
+        data.put("task-ptrs", taskPtrs);
 
         Task<Void> task = taskListRoot.document(documentName).set(data);
         Tasks.await(task);
     }
 
+    // Might not be needed anymore
     protected static void wipeTaskListData() throws ExecutionException, InterruptedException {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 

--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirestoreTaskTest.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/FirestoreTaskTest.java
@@ -101,7 +101,7 @@ public class FirestoreTaskTest {
 
     //@Test
     public void recoverTaskWorks() throws ExecutionException, InterruptedException {
-        HTask task = new HTask(new DummyUser("Dummy", "0"), BASIC_TASK_TITLE, BASIC_TASK_NAME);
+        HTask task = new HTask("0", BASIC_TASK_TITLE, BASIC_TASK_NAME);
         CollectionReference taskListRef = db.collection("task_dump");
 
         Map<String, Object> taskData = makeTaskData(task);
@@ -111,7 +111,7 @@ public class FirestoreTaskTest {
         HTask recoveredTask = FirestoreTask.recoverTask(taskData, taskListRef.document("tl1_test"));
 
         assertEquals(task.getTitle(), recoveredTask.getTitle());
-        assertEquals(task.getOwner().uid(), recoveredTask.getOwner().uid());
+        assertEquals(task.getOwner(), recoveredTask.getOwner());
         assertEquals(task.getDescription(), recoveredTask.getDescription());
 
         assertEquals(task.getSubTasks(), recoveredTask.getSubTasks());
@@ -165,7 +165,7 @@ public class FirestoreTaskTest {
         data.put("title", task.getTitle());
         data.put("description", task.getDescription());
         data.put("status", task.isFinished() ? STATUS_COMPLETED : STATUS_ONGOING);
-        data.put("owner", task.getOwner().uid());
+        data.put("owner", task.getOwner());
 
         List<Map<String, String>> subTaskListData = new ArrayList<>();
 

--- a/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/TaskListOnMainScreenTest.java
+++ b/app/src/androidTest/java/com/github/houseorganizer/houseorganizer/TaskListOnMainScreenTest.java
@@ -2,24 +2,32 @@ package com.github.houseorganizer.houseorganizer;
 
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.pressBack;
+import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
-import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.hasSibling;
 import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import androidx.test.espresso.contrib.RecyclerViewActions;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.github.houseorganizer.houseorganizer.panels.MainScreenActivity;
+import com.github.houseorganizer.houseorganizer.task.FirestoreTask;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.firestore.FirebaseFirestore;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -30,10 +38,15 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 
+/*
+* To add tests for: adding/removing tasks, changing task title [for now need bug fixes]
+*/
+
 @RunWith(AndroidJUnit4.class)
 public class TaskListOnMainScreenTest {
 
-    private static FirebaseFirestore db;
+    public static final String NEW_TASK_TITLE = "this is my task now";
+    public static final String NEW_SUBTASK_TITLE = "a new subtask!";
     private static FirebaseAuth auth;
 
     @BeforeClass
@@ -42,7 +55,6 @@ public class TaskListOnMainScreenTest {
         FirebaseTestsHelper.startFirestoreEmulator();
         FirebaseTestsHelper.setUpFirebase();
 
-        db = FirebaseFirestore.getInstance();
         auth = FirebaseAuth.getInstance();
     }
 
@@ -64,21 +76,127 @@ public class TaskListOnMainScreenTest {
     @Test
     public void addTaskButtonUIWorks() {
         onView(withId(R.id.new_task)).check(matches(isEnabled()));
-        //onView(withId(R.id.new_task)).check(matches(isDisplayed()));
+        onView(withId(R.id.new_task)).check(matches(isDisplayed()));
         onView(withId(R.id.new_task)).check(matches(isClickable()));
     }
 
-    // RecyclerView Tests [incomplete]
-    //@Test [NOT working - tasks not fully wiped from emulator]
+    // RecyclerView Tests
+
+    /* Display / navigation | DB: unchanged */
+    @Test
     public void taskViewHasCorrectNumberOfChildren() {
         onView(withId(R.id.task_list)).check(matches(hasChildCount(1)));
     }
 
-    //@Test [not working]
+    @Test
     public void taskTitleButtonDisplaysPopUpWhenClicked() {
-        onView(withId(R.id.task_list)).perform(RecyclerViewHelperActions.clickChildViewWithId(R.id.task_title));
-        onView(withText("TestTask")).inRoot(isDialog()).check(matches(isDisplayed()));
-        onView(withText("Testing")).inRoot(isDialog()).check(matches(isDisplayed()));
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
 
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).inRoot(isDialog()).check(matches(isDisplayed()));
+        onView(withText(FirebaseTestsHelper.TEST_TASK_DESC)).inRoot(isDialog()).check(matches(isDisplayed()));
     }
+
+    @Test
+    public void assigneePopUpIsDisplayed() {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+        onView(withText(R.string.assignees_button)).perform(click());
+
+        // This line will be changed to the user of the household
+        onView(withText("aindreias@houseorganizer.com")).inRoot(isDialog()).check(matches(isDisplayed()));
+    }
+
+    /* Actions work [changing title [tbd], description, adding/removing subtasks, adding/removing assignees */
+    /* [!] BUG: changing the title crashes the app (Tasks::await call in FirestoreTask)
+    => not tested for now */
+
+    @Test /* DB: unchanged */
+    public void changingDescriptionWorks() throws ExecutionException, InterruptedException {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+
+        /* UI check */
+        onView(withId(R.id.task_description_input)).perform(clearText(),
+                typeText(NEW_TASK_TITLE), closeSoftKeyboard());
+
+        onView(withText(NEW_TASK_TITLE)).inRoot(isDialog()).check(matches(isDisplayed()));
+
+        /* DB check */
+        FirestoreTask ft = FirestoreTaskTest.recoverFirestoreTask();
+        assertEquals(NEW_TASK_TITLE, ft.getDescription());
+
+        // Undoing
+        onView(withId(R.id.task_description_input)).perform(clearText(),
+                typeText(FirebaseTestsHelper.TEST_TASK_DESC), closeSoftKeyboard());
+    }
+
+    @Test /* DB: unchanged */
+    public void addSubTaskWorks() throws ExecutionException, InterruptedException {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+        onView(withText(R.string.add_subtask)).perform(click());
+
+        /* UI check */
+        onView(withId(R.id.subtask_title_input)).inRoot(isDialog()).check(matches(isDisplayed()));
+
+        /* DB check */
+        FirestoreTask ft = FirestoreTaskTest.recoverFirestoreTask();
+        assertEquals(1, ft.getSubTasks().size());
+
+        // Undoing
+        onView(withId(R.id.subtask_done_button)).perform(click());
+    }
+
+    @Test /* DB: unchanged */
+    public void changingSubTaskTitleWorks() throws ExecutionException, InterruptedException {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+
+        onView(withText(R.string.add_subtask)).perform(click());
+        onView(withId(R.id.subtask_title_input)).perform(clearText(),
+                typeText(NEW_SUBTASK_TITLE), closeSoftKeyboard());
+
+        /* UI check */
+        onView(withText(NEW_SUBTASK_TITLE)).inRoot(isDialog()).check(matches(isDisplayed()));
+        onView(withId(R.id.subtask_list)).check(matches(hasChildCount(1)));
+
+        /* DB check */
+        FirestoreTask ft = FirestoreTaskTest.recoverFirestoreTask();
+        assertEquals(NEW_SUBTASK_TITLE, ft.getSubTaskAt(0).getTitle());
+
+        // Undoing
+        onView(withId(R.id.subtask_done_button)).perform(click());
+    }
+
+    @Test /* DB: unchanged */
+    public void removingSubTaskWorks() throws ExecutionException, InterruptedException {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+
+        onView(withText(R.string.add_subtask)).perform(click());
+        onView(withId(R.id.subtask_done_button)).perform(click());
+
+        /* UI check */
+        onView(withText("Congratulations!")).inRoot(isDialog()).check(matches(isDisplayed())).perform(pressBack());
+        onView(withId(R.id.subtask_list)).check(matches(hasChildCount(0)));
+
+        /* DB double-check */
+        assertFalse(FirestoreTaskTest.recoverFirestoreTask().hasSubTasks());
+    }
+
+    /* Assignee tests don't use the DB for now */
+    @Test /* DB: not used */
+    public void assigneeButtonWorks() {
+        onView(withText(FirebaseTestsHelper.TEST_TASK_TITLE)).perform(click());
+        onView(withText(R.string.assignees_button)).perform(click());
+
+        onView(hasSibling(withText("aindreias@houseorganizer.com"))).perform(click());
+
+        /* UI check */
+        onView(hasSibling(withText("aindreias@houseorganizer.com")))
+                .check(matches(withTagValue(equalTo(R.drawable.remove_person))));
+
+        // Undoing + UI check
+        onView(hasSibling(withText("aindreias@houseorganizer.com"))).perform(click());
+        onView(hasSibling(withText("aindreias@houseorganizer.com")))
+                .check(matches(withTagValue(equalTo(R.drawable.add_person))));
+    }
+
+    /* Add / remove tasks test postponed
+    [BUG] removing a task doesn't delete the taskPtr in the task list metadata */
 }

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
@@ -91,11 +91,13 @@ public class MainScreenActivity extends AppCompatActivity {
         List<String> memberEmails = Arrays.asList("aindreias@houseorganizer.com", "sansive@houseorganizer.com",
                 "shau@reds.com", "oxydeas@houseorganizer.com");
 
-        db.collection("task-lists")
+        db.collection("task_lists")
                 .whereEqualTo("hh-id", currentHouse.getId())
                 .get().addOnCompleteListener(task -> {
                     if (task.isSuccessful()) {
-                        this.tlMetadata = task.getResult().getDocuments().get(0).getReference();
+                        System.out.println(currentHouse.getId());
+                        QueryDocumentSnapshot qds = task.getResult().iterator().next();
+                        this.tlMetadata = db.collection("task_lists").document(qds.getId());
                         this.taskList = new TaskList(currentUser, "My weekly todo", new ArrayList<>());
                         this.taskListAdapter = new TaskListAdapter(taskList, memberEmails);
                         TaskView.recoverTaskList(this, taskList, taskListAdapter, tlMetadata);

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
@@ -56,6 +56,7 @@ public class MainScreenActivity extends AppCompatActivity {
     private RecyclerView calendarEvents;
 
     private TaskList taskList;
+    private DocumentReference tlMetadata;
     private TaskListAdapter taskListAdapter;
     private ListFragmentView listView = ListFragmentView.CHORES_LIST;
     public enum ListFragmentView { CHORES_LIST, GROCERY_LIST }
@@ -83,19 +84,23 @@ public class MainScreenActivity extends AppCompatActivity {
         findViewById(R.id.calendar_view_change).setOnClickListener(v -> calendar.rotateCalendarView(v, this, calendarAdapter, calendarEvents));
         findViewById(R.id.add_event).setOnClickListener(this::addEvent);
         findViewById(R.id.refresh_calendar).setOnClickListener(this::refreshCalendar);
-        findViewById(R.id.new_task).setOnClickListener(v -> TaskView.addTask(db, taskList, taskListAdapter, listView));
-
-        initializeTaskList();
-        TaskView.recoverTaskList(this, taskList, taskListAdapter,
-                db.collection("task_lists").document("85IW3cYzxOo1YTWnNOQl"));
+        findViewById(R.id.new_task).setOnClickListener(v -> TaskView.addTask(db, taskList, taskListAdapter, listView, tlMetadata));
     }
 
     private void initializeTaskList() {
         List<String> memberEmails = Arrays.asList("aindreias@houseorganizer.com", "sansive@houseorganizer.com",
                 "shau@reds.com", "oxydeas@houseorganizer.com");
 
-        this.taskList = new TaskList(currentUser, "My weekly todo", new ArrayList<>());
-        this.taskListAdapter = new TaskListAdapter(taskList, memberEmails);
+        db.collection("task-lists")
+                .whereEqualTo("hh-id", currentHouse.getId())
+                .get().addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        this.tlMetadata = task.getResult().getDocuments().get(0).getReference();
+                        this.taskList = new TaskList(currentUser, "My weekly todo", new ArrayList<>());
+                        this.taskListAdapter = new TaskListAdapter(taskList, memberEmails);
+                        TaskView.recoverTaskList(this, taskList, taskListAdapter, tlMetadata);
+                    }
+        });
     }
 
     @Override
@@ -120,10 +125,10 @@ public class MainScreenActivity extends AppCompatActivity {
         SharedPreferences sharedPreferences = getSharedPrefs(this);
         String householdId = sharedPreferences.getString(CURRENT_HOUSEHOLD, "");
 
-        loadHousehold(householdId);
+        loadHouseholdAndTaskList(householdId);
     }
 
-    private void loadHousehold(String householdId) {
+    private void loadHouseholdAndTaskList(String householdId) {
         db.collection("households").whereArrayContains("residents", Objects.requireNonNull(mUser.getEmail())).get().addOnCompleteListener(task -> {
                     if (task.isSuccessful()) {
                         ArrayList<String> households = new ArrayList<>();
@@ -145,6 +150,8 @@ public class MainScreenActivity extends AppCompatActivity {
                             }
                         }
                         refreshCalendar(findViewById(R.id.refresh_calendar));
+
+                        initializeTaskList();
                     } else
                         logAndToast("MainScreenActivity", "loadHousehold:failure", task.getException(),
                                 getApplicationContext(), "Could not get a house.");

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
@@ -98,7 +98,7 @@ public class MainScreenActivity extends AppCompatActivity {
                         System.out.println(currentHouse.getId());
                         QueryDocumentSnapshot qds = task.getResult().iterator().next();
                         this.tlMetadata = db.collection("task_lists").document(qds.getId());
-                        this.taskList = new TaskList(currentUser, "My weekly todo", new ArrayList<>());
+                        this.taskList = new TaskList(currentUser.uid(), "My weekly todo", new ArrayList<>());
                         this.taskListAdapter = new TaskListAdapter(taskList, memberEmails);
                         TaskView.recoverTaskList(this, taskList, taskListAdapter, tlMetadata);
                     }

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
@@ -151,8 +151,7 @@ public class MainScreenActivity extends AppCompatActivity {
                                 hideButtons();
                             }
                         }
-                        refreshCalendar(findViewById(R.id.refresh_calendar));
-                        initializeTaskList();
+                        refreshCalendar(findViewById(R.id.refresh_calendar)); initializeTaskList();
                     } else
                         logAndToast("MainScreenActivity", "loadHousehold:failure", task.getException(),
                                 getApplicationContext(), "Could not get a house.");

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/panels/MainScreenActivity.java
@@ -152,7 +152,6 @@ public class MainScreenActivity extends AppCompatActivity {
                             }
                         }
                         refreshCalendar(findViewById(R.id.refresh_calendar));
-
                         initializeTaskList();
                     } else
                         logAndToast("MainScreenActivity", "loadHousehold:failure", task.getException(),

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
@@ -92,7 +92,12 @@ public final class FirestoreTask extends HTask {
     }
 
     public static HTask.SubTask recoverSubTask(Map<String, String> data) {
-        return new HTask.SubTask(data.get("title"));
+        SubTask st = new HTask.SubTask(data.get("title"));
+
+        if(data.get("status").equals("completed"))
+            st.markAsFinished();
+
+        return st;
     }
 
     public static FirestoreTask recoverTask(Map<String, Object> data, DocumentReference taskDocRef) {

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
@@ -1,7 +1,5 @@
 package com.github.houseorganizer.houseorganizer.task;
 
-import com.github.houseorganizer.houseorganizer.user.DummyUser;
-import com.github.houseorganizer.houseorganizer.user.User;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FieldValue;
@@ -16,7 +14,7 @@ import java.util.stream.Collectors;
 public final class FirestoreTask extends HTask {
     private final DocumentReference taskDocRef;
 
-    public FirestoreTask(User owner, String title, String description, List<SubTask> subTasks, DocumentReference taskDocRef) {
+    public FirestoreTask(String owner, String title, String description, List<SubTask> subTasks, DocumentReference taskDocRef) {
         super(owner, title, description);
 
         subTasks.forEach(super::addSubTask);
@@ -99,10 +97,10 @@ public final class FirestoreTask extends HTask {
 
     public static FirestoreTask recoverTask(Map<String, Object> data, DocumentReference taskDocRef) {
         List<SubTask> subTasks = collectSubTasks(data);
-        List<User> assignees = collectAssignees(data);
+        List<String> assignees = collectAssignees(data);
 
-        FirestoreTask ft = new FirestoreTask(new DummyUser("Recovering-user", (String)data.get("owner")),
-                (String)data.get("title"), (String)data.get("description"), subTasks, taskDocRef);
+        FirestoreTask ft = new FirestoreTask((String)data.get("owner"), (String)data.get("title"),
+                (String)data.get("description"), subTasks, taskDocRef);
 
         ft.getAssignees().addAll(assignees);
 
@@ -110,7 +108,6 @@ public final class FirestoreTask extends HTask {
     }
 
     private static List<SubTask> collectSubTasks(Map<String, Object> taskData) {
-        System.out.println("AAAAAAAAA" + taskData);
         List<SubTask> subTasks = new ArrayList<>();
         Object tmpSubTaskData = taskData.get("sub tasks");
 
@@ -123,14 +120,12 @@ public final class FirestoreTask extends HTask {
         return subTasks;
     }
 
-    private static List<User> collectAssignees(Map<String, Object> taskData) {
-        List<User> assignees = new ArrayList<>();
+    private static List<String> collectAssignees(Map<String, Object> taskData) {
+        List<String> assignees = new ArrayList<>();
         Object assigneeData = taskData.get("assignees");
 
         if (null != assigneeData) {
-            assignees = ((List<String>) assigneeData).stream()
-                    .map(assigneeEmail -> new DummyUser("Dummy", assigneeEmail))
-                    .collect(Collectors.toList());
+            assignees = (List<String>) assigneeData;
         }
 
         return assignees;

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/FirestoreTask.java
@@ -110,6 +110,7 @@ public final class FirestoreTask extends HTask {
     }
 
     private static List<SubTask> collectSubTasks(Map<String, Object> taskData) {
+        System.out.println("AAAAAAAAA" + taskData);
         List<SubTask> subTasks = new ArrayList<>();
         Object tmpSubTaskData = taskData.get("sub tasks");
 

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/HTask.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/HTask.java
@@ -1,7 +1,5 @@
 package com.github.houseorganizer.houseorganizer.task;
 
-import com.github.houseorganizer.houseorganizer.user.User;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,12 +9,13 @@ public class HTask {
     private String title, description;
     private final List<SubTask> subtasks;
 
-    private final List<User> assignees;
-    private final User owner;
+    /* UIDs */
+    private final List<String> assignees;
+    private final String owner;
 
     private LocalDateTime dueDate;
 
-    public HTask(User owner, String title, String description) {
+    public HTask(String owner, String title, String description) {
         this.title       = title;
         this.description = description;
         this.subtasks    = new ArrayList<>();
@@ -41,7 +40,7 @@ public class HTask {
         this.description = newDescription;
     }
 
-    public void assignTo(User assignee) {
+    public void assignTo(String assignee) {
         this.assignees.add(assignee);
     }
 
@@ -86,7 +85,7 @@ public class HTask {
         return description;
     }
 
-    public User getOwner() {
+    public String getOwner() {
         return owner;
     }
 
@@ -95,7 +94,7 @@ public class HTask {
     }
 
     /* [!] returns assignee list as-is s.t. adapters can modify it */
-    public List<User> getAssignees() {
+    public List<String> getAssignees() {
         return assignees;
     }
 

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/SubTaskAdapter.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/SubTaskAdapter.java
@@ -39,8 +39,8 @@ public final class SubTaskAdapter extends RecyclerView.Adapter<BiViewHolder<Butt
                     //parentTask.getSubTaskAt(position).markAsFinished();
                     parentTask.removeSubTask(position);
                     new AlertDialog.Builder(v.getContext())
-                            .setTitle("Congratulations!")
-                            .setMessage("You just completed a subtask. Keep it up!")
+                            .setTitle(R.string.task_completion_title)
+                            .setMessage(R.string.subtask_completion_desc)
                             .show();
 
                     notifyItemRemoved(position);

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskAssigneeAdapter.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskAssigneeAdapter.java
@@ -8,7 +8,6 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.github.houseorganizer.houseorganizer.R;
-import com.github.houseorganizer.houseorganizer.user.DummyUser;
 import com.github.houseorganizer.houseorganizer.util.BiViewHolder;
 
 import java.util.List;
@@ -25,7 +24,7 @@ public class TaskAssigneeAdapter extends RecyclerView.Adapter<BiViewHolder<TextV
     private boolean isAmongAssignees(String userEmail) {
         return parentTask.getAssignees()
                 .stream()
-                .anyMatch(u -> u.uid().equals(userEmail));
+                .anyMatch(uid -> uid.equals(userEmail));
     }
 
     @NonNull
@@ -63,10 +62,10 @@ public class TaskAssigneeAdapter extends RecyclerView.Adapter<BiViewHolder<TextV
     }
 
     private void removeAssignee(String userEmail) {
-        parentTask.getAssignees().removeIf(u -> u.uid().equals(userEmail));
+        parentTask.getAssignees().removeIf(uid -> uid.equals(userEmail));
     }
 
     private void addAssignee(String userEmail) {
-        parentTask.assignTo(new DummyUser("User", userEmail));
+        parentTask.assignTo(userEmail);
     }
 }

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskAssigneeAdapter.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskAssigneeAdapter.java
@@ -43,7 +43,9 @@ public class TaskAssigneeAdapter extends RecyclerView.Adapter<BiViewHolder<TextV
         boolean isAssigned = isAmongAssignees(assigneeEmail);
         assigneeEmailTextView.setText(assigneeEmail);
 
-        imgButton.setBackgroundResource(isAssigned ? R.drawable.remove_person : R.drawable.add_person);
+        int rscId = isAssigned ? R.drawable.remove_person : R.drawable.add_person;
+        imgButton.setBackgroundResource(rscId);
+        imgButton.setTag(rscId);
 
         imgButton.setOnClickListener(v -> {
             if(isAssigned) {

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskList.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskList.java
@@ -1,16 +1,14 @@
 package com.github.houseorganizer.houseorganizer.task;
 
-import com.github.houseorganizer.houseorganizer.user.User;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public final class TaskList {
-    private final User owner;
+    private final String owner; /* UID */
     private final List<HTask> tasks;
     private String title;
 
-    public TaskList(User owner, String title, List<HTask> initialTasks) {
+    public TaskList(String owner, String title, List<HTask> initialTasks) {
         this.owner = owner;
         this.title = title;
         this.tasks = new ArrayList<>(initialTasks);
@@ -45,7 +43,7 @@ public final class TaskList {
     }
 
     // Getters
-    public User getOwner() {
+    public String getOwner() {
         return owner;
     }
 

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
@@ -18,11 +18,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.github.houseorganizer.houseorganizer.R;
 import com.github.houseorganizer.houseorganizer.panels.MainScreenActivity;
 import com.github.houseorganizer.houseorganizer.util.BiViewHolder;
-import com.google.android.gms.tasks.Task;
+
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.QuerySnapshot;
+
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -126,10 +126,12 @@ public final class TaskView {
         taskListDocRef.get().addOnCompleteListener(task -> {
             if(task.isSuccessful()) {
                 Map<String, Object> metadata = task.getResult().getData();
+                assert metadata != null;
 
                 List<DocumentReference> taskPtrs = (ArrayList<DocumentReference>)
                         metadata.getOrDefault("task-ptrs", new ArrayList<>());
 
+                assert taskPtrs != null;
                 taskPtrs.add(taskDocRef);
 
                 metadata.put("task-ptrs", taskPtrs);

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
@@ -20,7 +20,6 @@ import com.github.houseorganizer.houseorganizer.panels.MainScreenActivity;
 import com.github.houseorganizer.houseorganizer.util.BiViewHolder;
 
 import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 
@@ -28,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 public final class TaskView {
@@ -78,16 +76,16 @@ public final class TaskView {
                 List<DocumentReference> taskPtrs = (ArrayList<DocumentReference>)
                         metadata.getOrDefault("task-ptrs", new ArrayList<>());
 
+                assert taskPtrs != null;
+
                 // We're adding `FirestoreTask`s now, and the in-app changes to
                 // their title and/or description will be reflected in the database
-                taskPtrs.forEach(ptr -> {
-                    ptr.get().addOnCompleteListener( task2 -> {
-                        if (task2.isSuccessful()) {
-                            Map<String, Object> taskData = task2.getResult().getData();
-                            taskList.addTask(FirestoreTask.recoverTask(taskData, ptr));
-                        }
-                    });
-                });
+                taskPtrs.forEach(ptr -> ptr.get().addOnCompleteListener(task2 -> {
+                    if (task2.isSuccessful()) {
+                        Map<String, Object> taskData = task2.getResult().getData();
+                        taskList.addTask(FirestoreTask.recoverTask(taskData, ptr));
+                    }
+                }));
 
                 setUpTaskListView(parent, taskListAdapter);
             }

--- a/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
+++ b/app/src/main/java/com/github/houseorganizer/houseorganizer/task/TaskView.java
@@ -111,7 +111,7 @@ public final class TaskView {
                     if (task.isSuccessful()) {
                         DocumentReference taskDocRef = task.getResult();
 
-                        taskList.addTask(new FirestoreTask(taskList.getOwner(), "", "", new ArrayList<>(), taskDocRef));
+                        taskList.addTask(new FirestoreTask(taskList.getOwner(), "Untitled task", "", new ArrayList<>(), taskDocRef));
                         taskListAdapter.notifyItemInserted(taskListAdapter.getItemCount()-1);
 
                         addTaskPtrToMetadata(taskListDocRef, taskDocRef);

--- a/app/src/test/java/com/github/houseorganizer/houseorganizer/HTaskUnitTest.java
+++ b/app/src/test/java/com/github/houseorganizer/houseorganizer/HTaskUnitTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.github.houseorganizer.houseorganizer.task.HTask;
-import com.github.houseorganizer.houseorganizer.user.User;
 
 import org.junit.Test;
 
@@ -14,26 +13,8 @@ import java.util.List;
 
 
 public class HTaskUnitTest {
-    public static class DummyUser extends User {
-        private final String name, uid;
 
-        DummyUser(String name, String uid) {
-            this.name = name;
-            this.uid = uid;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public String uid() {
-            return uid;
-        }
-    }
-
-    public static final User NOBODY = new DummyUser("Nobody", "NOBODY");
+    public static final String NOBODY = "NOBODY";
 
     // Subtask tests
     @Test
@@ -65,7 +46,7 @@ public class HTaskUnitTest {
     public void taskConstructorWorks() {
         HTask t = new HTask(NOBODY, "Task 1", "stub description");
 
-        assertEquals(NOBODY.uid(), t.getOwner().uid());
+        assertEquals(NOBODY, t.getOwner());
         assertEquals("Task 1", t.getTitle());
         assertEquals("stub description", t.getDescription());
 
@@ -99,7 +80,7 @@ public class HTaskUnitTest {
         HTask t = new HTask(NOBODY, "Task 1", "stub description");
 
         t.assignTo(NOBODY);
-        assertEquals(NOBODY.uid(), t.getAssignees().get(0).uid());
+        assertEquals(NOBODY, t.getAssignees().get(0));
         assertTrue(t.hasAssignees());
     }
 

--- a/app/src/test/java/com/github/houseorganizer/houseorganizer/TaskListUnitTest.java
+++ b/app/src/test/java/com/github/houseorganizer/houseorganizer/TaskListUnitTest.java
@@ -20,7 +20,7 @@ public class TaskListUnitTest {
         TaskList tl = new TaskList(HTaskUnitTest.NOBODY, "TaskList 1", new ArrayList<>());
 
         assertFalse(tl.hasTasks());
-        assertEquals(HTaskUnitTest.NOBODY.uid(), tl.getOwner().uid());
+        assertEquals(HTaskUnitTest.NOBODY, tl.getOwner());
         assertEquals("TaskList 1", tl.getTitle());
     }
 
@@ -36,7 +36,7 @@ public class TaskListUnitTest {
         TaskList tl = new TaskList(HTaskUnitTest.NOBODY, "TaskList 1", tasks);
 
         assertTrue(tl.hasTasks());
-        assertEquals(HTaskUnitTest.NOBODY.uid(), tl.getOwner().uid());
+        assertEquals(HTaskUnitTest.NOBODY, tl.getOwner());
         assertEquals("TaskList 1", tl.getTitle());
 
         assertEquals(t, tl.getTaskAt(0));


### PR DESCRIPTION
**Changes**
- task list data is now broken up into 1 document per task (/task_dump/...) and a metadata file (/task_lists/...), which stores among other things a list of task pointers
 - `HTask` no longer uses the `User` interface for owners & assignees, instead it uses a `String`
 - UI + DB reflection tests for the task list fragment on MainScreenActivity

**Bugs** _(not tested, to be addressed this/next sprint)_
- changing the title of a task crashes the app (due to a `Tasks::await` call in `FirestoreTask`)
- removing a task doesn't update the pointer list in the metadata file